### PR TITLE
added only for auth rls for actions table

### DIFF
--- a/supabase/migrations/20231114190913_add_actions_row_level_security.sql
+++ b/supabase/migrations/20231114190913_add_actions_row_level_security.sql
@@ -1,0 +1,17 @@
+CREATE POLICY "delete_actions_auth_policy"
+ON public.actions
+FOR DELETE USING (
+  auth.uid() = initiator_id
+);
+
+CREATE POLICY "insert_actions_auth_policy"
+ON public.actions
+FOR INSERT WITH CHECK (
+  auth.uid() = initiator_id
+);  
+
+CREATE POLICY "update_actions_auth_policy"
+ON public.actions
+FOR UPDATE WITH CHECK (
+    auth.uid() = initiator_id
+);


### PR DESCRIPTION
added insert, delete and update row level security policies, so that such operations may be executed only by the initiators of the actions